### PR TITLE
secure outputs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -199,7 +199,7 @@ async function uploadthisfile(filearr, workflowid) {
   if (filearr.uploadadminzone) {
     if (process.env.IPFS_ADMINLOGS) {
 
-      url = await uploadtoIPFS(filearr, workflowid, process.env.IPFS_ADMINLOGS, process.env.IPFS_ADMINLOGS_PREFIX, process.env.IPFS_EXPIRY_TIME)
+      url = await uploadtoIPFS(filearr, workflowid, process.env.IPFS_ADMINLOGS, process.env.IPFS_ADMINLOGS_PREFIX, process.env.STORAGE_EXPIRY, process.env.IPFS_API_KEY, process.env.IPFS_API_CLIENT)
     }
     else if (process.env.AWS_BUCKET_ADMINLOGS) {
       url = await uploadtos3(filearr, workflowid, process.env.AWS_BUCKET_ADMINLOGS)
@@ -211,7 +211,7 @@ async function uploadthisfile(filearr, workflowid) {
   }
   else {
     if (process.env.IPFS_OUTPUT) {
-      url = await uploadtoIPFS(filearr, workflowid, process.env.IPFS_OUTPUT, process.env.IPFS_OUTPUT_PREFIX, process.env.IPFS_EXPIRY_TIME)
+      url = await uploadtoIPFS(filearr, workflowid, process.env.IPFS_OUTPUT, process.env.IPFS_OUTPUT_PREFIX, process.env.STORAGE_EXPIRY, process.env.IPFS_API_KEY, process.env.IPFS_API_CLIENT)
     }
     else if (process.env.AWS_BUCKET_OUTPUT) {
       url = await uploadtos3(filearr, workflowid, process.env.AWS_BUCKET_OUTPUT)
@@ -262,10 +262,17 @@ async function uploadtos3(filearr, workflowid, bucketName) {
 }
 
 
-async function uploadtoIPFS(filearr, workflowid, ipfsURL, ipfsURLPrefix, expiry) {
+async function uploadtoIPFS(filearr, workflowid, ipfsURL, ipfsURLPrefix, expiry, ipfsApiKey, ipfsApiClient) {
   console.log("Publishing to IPFS with options:")
   try {
-    const ipfs = ipfsClient(ipfsURL)
+    let headers = {}
+    if (ipfsApiKey) {
+      headers['X-API-KEY'] = ipfsApiKey
+    }
+    if (ipfsApiClient) {
+      headers['CLIENT-ID'] = ipfsApiClient
+    }
+    const ipfs = ipfsClient({ url: ipfsURL, headers: headers })
     let fileStream = fs.createReadStream(filearr.path)
     let fileDetails = {
       path: filearr.path,

--- a/src/index.js
+++ b/src/index.js
@@ -282,7 +282,10 @@ async function uploadtoIPFS(filearr, workflowid, ipfsURL, ipfsURLPrefix, expiry,
     if (expiry) {
       options = Object()
       options['wrapWithDirectory'] = true
-      options['expire-in'] = expiry
+      /* (see https://github.com/ipfs/ipfs-cluster/blob/dbca14e83295158558234e867477ce07a523b81b/CHANGELOG.md#rest-api-2_)
+      Since IPFS expects value in Go's time format, i.e. 12h, we are going to divide the expiry to 60 and round it up
+      */
+      options['expire-in'] = Math.ceil(int(expiry)/60)
     }
     else {
       options = {


### PR DESCRIPTION
Closes #14

Instead of storing only urls in outputURL, we are storing an array for each record.

The array looks like:

{
        filename,
        filesize,
        url,
        type: 'algorithmLog'  OR 'output'
      }
